### PR TITLE
Typecasting added to support 32-bit controllers.

### DIFF
--- a/MPU6050.cpp
+++ b/MPU6050.cpp
@@ -373,9 +373,9 @@ Vector MPU6050::readRawAccel(void)
 	uint8_t zla = Wire.receive();
     #endif
 
-    ra.XAxis = xha << 8 | xla;
-    ra.YAxis = yha << 8 | yla;
-    ra.ZAxis = zha << 8 | zla;
+    ra.XAxis = (int16_t)(xha << 8 | xla);
+    ra.YAxis = (int16_t)(yha << 8 | yla);
+    ra.ZAxis = (int16_t)(zha << 8 | zla);
 
     return ra;
 }
@@ -434,9 +434,9 @@ Vector MPU6050::readRawGyro(void)
 	uint8_t zla = Wire.receive();
     #endif
 
-    rg.XAxis = xha << 8 | xla;
-    rg.YAxis = yha << 8 | yla;
-    rg.ZAxis = zha << 8 | zla;
+    rg.XAxis = (int16_t)(xha << 8 | xla);
+    rg.YAxis = (int16_t)(yha << 8 | yla);
+    rg.ZAxis = (int16_t)(zha << 8 | zla);
 
     return rg;
 }


### PR DESCRIPTION
For 32-bit controllers size of Integer is 32-bit which does not treat 16-bit 2's complement value +/- ve but only as 16-bit +ve Integer as the first MSB is always 0.